### PR TITLE
fixed generating nested array query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-All notable changes to `guzzle-assertions` will be documented in this file.
+All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## NEXT - YYYY-MM-DD
+## [0.1.2] - 2018-06-21
 
 ### Added
 - Nothing
@@ -13,7 +13,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Nothing
 
 ### Fixed
-- Nothing
+- fixed generating nested array query strings
 
 ### Removed
 - Nothing

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -2,12 +2,11 @@
 
 namespace Muzzle;
 
-use Throwable;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use function GuzzleHttp\Psr7\build_query;
+use Throwable;
 use function GuzzleHttp\Psr7\parse_query;
 
 class RequestBuilder
@@ -126,7 +125,10 @@ class RequestBuilder
     public function build() : Request
     {
 
-        $uri = $this->uri->withQuery(build_query(array_merge(parse_query($this->uri->getQuery()), $this->query)));
+        $uri = $this->uri->withQuery(http_build_query(array_merge(
+            parse_query($this->uri->getQuery()),
+            $this->query
+        )));
 
         return new Request($this->method->getValue(), $uri, $this->headers, $this->body);
     }

--- a/tests/RequestBuilderTest.php
+++ b/tests/RequestBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Muzzle;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class RequestBuilderTest extends TestCase
+{
+
+    /** @test */
+    public function itCanConstructARequest()
+    {
+
+        $builder = new RequestBuilder;
+
+        $request = $builder
+            ->setMethod(HttpMethod::GET())
+            ->setUri('http://example.com')
+            ->setQuery(['foo' => 'bar'])
+            ->setHeaders(['Accept' => 'application/json'])
+            ->build();
+
+        $this->assertInstanceOf(RequestInterface::class, $request);
+        $this->assertEquals('http://example.com?foo=bar', $request->getUri());
+    }
+
+    /** @test */
+    public function itCanConstructARequestUriWithNestedQueryParameters()
+    {
+
+        $builder = new RequestBuilder;
+
+        $request = $builder
+            ->setMethod(HttpMethod::GET())
+            ->setUri('http://example.com')
+            ->setQuery(['foo' => [['bar' => ['baz', 'qux']]]])
+            ->build();
+
+        $this->assertEquals(
+            'http://example.com?foo[0][bar][0]=baz&foo[0][bar][1]=qux',
+            urldecode($request->getUri())
+        );
+    }
+}


### PR DESCRIPTION
## Description

Updates the `RequestBuilder` to use `http_build_query` as the Guzzle function `build_query` doesn't update the keys when a nested array query is used.

## Motivation and context

```php
$query = ['users' => [['name' => 'John'], ['name' => 'Jane']]];

build_query($query); 
// throws: rawurlencode() expects parameter 1 to be string, array given

http_build_query($query); 
// users%5B0%5D%5Bname%5D=John&users%5B1%5D%5Bname%5D=Jane
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
