### PR TITLE
Route Pattern Matching for Path Assertions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/bbrothers/guzzle-assertions).
+We accept contributions via Pull Requests on [Github](https://github.com/bbrothers/muzzle).
 
 
 ## Pull Requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-All notable changes to `guzzle-assertions` will be documented in this file.
+All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## NEXT - YYYY-MM-DD
+## [0.1.2] - 2018-06-21
 
 ### Added
-- Nothing
+- route pattern matching on path assertions
 
 ### Deprecated
 - Nothing

--- a/src/Messages/AssertableRequest.php
+++ b/src/Messages/AssertableRequest.php
@@ -3,6 +3,7 @@
 namespace Muzzle\Messages;
 
 use GuzzleHttp\Psr7;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\RequestInterface;
 
@@ -157,14 +158,22 @@ class AssertableRequest implements RequestInterface
 
     /**
      * Assert that the given string matches the path component of the URI.
+     * Wildcard matches can be represented by an asterisk (*)
      *
-     * @param  string $path
+     * @param  string $pattern
      * @return $this
      */
-    public function assertUriPath($path)
+    public function assertUriPath($pattern)
     {
 
-        PHPUnit::assertEquals($path, $this->getUri()->getPath());
+        PHPUnit::assertTrue(
+            Str::is($pattern, $this->getUri()->getPath()),
+            sprintf(
+                'The path [%s] does not match the expected pattern [%s].',
+                $this->getUri()->getPath(),
+                $pattern
+            )
+        );
 
         return $this;
     }

--- a/src/Messages/AssertableRequest.php
+++ b/src/Messages/AssertableRequest.php
@@ -71,7 +71,15 @@ class AssertableRequest implements RequestInterface
     public function assertMethod(string $method)
     {
 
-        PHPUnit::assertEquals(strtoupper($method), $this->getMethod());
+        PHPUnit::assertEquals(
+            strtoupper($method),
+            $this->getMethod(),
+            sprintf(
+                'Expected HTTP method [%s]. Got [%s]',
+                strtoupper($method),
+                $this->getMethod()
+            )
+        );
 
         return $this;
     }

--- a/src/WrapsGuzzle.php
+++ b/src/WrapsGuzzle.php
@@ -2,7 +2,6 @@
 
 namespace Muzzle;
 
-use BadMethodCallException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Muzzle\Messages\AssertableResponse;
 use OutOfBoundsException;
@@ -94,6 +93,7 @@ trait WrapsGuzzle
                 $method,
                 $dumper->dump((new VarCloner)->cloneVar($arguments), true)
             ));
+            throw $exception;
         }
-    } // @codeCoverageIgnore
+    }
 }

--- a/tests/Assertions/UriPathMatchesTest.php
+++ b/tests/Assertions/UriPathMatchesTest.php
@@ -58,4 +58,27 @@ class UriPathMatchesTest extends TestCase
 
         $assertion->assert($actualUri, $expectedUri);
     }
+
+
+    /** @test */
+    public function itAllowsMatchingWildcardParameters()
+    {
+
+        $muzzle = $this->prophesize(Muzzle::class);
+        $muzzle->getConfig('base_uri')
+               ->willReturn(new Uri('https://example.com/api'));
+
+        $expected = (new Transaction)->setRequest(
+            (new RequestBuilder)->setUri('/foo/*/bar')->build()
+        );
+        $actual = (new Transaction)->setRequest(
+            new AssertableRequest((new RequestBuilder)->setUri('/foo/123/bar')->build())
+        );
+
+        $this->assertTrue((function () use ($muzzle, $actual, $expected) {
+
+            (new UriPathMatches($muzzle->reveal()))->assert($actual, $expected);
+            return true;
+        })());
+    }
 }

--- a/tests/Messages/AssertableRequestTest.php
+++ b/tests/Messages/AssertableRequestTest.php
@@ -145,6 +145,21 @@ class AssertableRequestTest extends TestCase
     }
 
     /** @test */
+    public function itCanAssertThatTheRequestUriPathMatchesTheProvidedPattern()
+    {
+
+        $request = new AssertableRequest(
+            new Request(HttpMethod::GET, 'https://user:password@example.com:80/foo/123/abc?bar=baz&qux=quux')
+        );
+
+        $request->assertUriPath('/foo/*/abc');
+        $request->assertUriPath('/foo/*');
+
+        $this->expectException(ExpectationFailedException::class);
+        $request->assertUriPath('/foo/*/');
+    }
+
+    /** @test */
     public function itCanAssertThatTheRequestUriFragmentMatchesTheProvidedValue()
     {
 


### PR DESCRIPTION
## Description

This PR allows for wildcard parameters to be passed when making assertions on the expected request path.

```php
$request = new Request(HttpMethod::GET, '/foo/123/bar');
$assertable = new AssertableRequest($request);
$assertable->assertUriPath('/foo/*/bar'); // pass
$assertable->assertUriPath('/foo/*'); // pass
$assertable->assertUriPath('/foo/*/'); // fail
```

## Motivation and context

Often we don't need to care about a variable value for a given test. This allows us to do a basic match and then move on to the primary focus of the test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
