### PR TITLE
Improved `Transactions` Usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## [0.1.2] - 2018-06-21
+## [0.1.2] - 2018-06-22
 
 ### Added
 - route pattern matching on path assertions
+- improved `Transactions` usability
+- added shortcut methods to first and last request on the `Muzzle` instance
 
 ### Deprecated
 - Nothing

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $this->assertInstanceOf(Muzzle::class, $client);
 $client->post('https://example.com/contact')->assertSuccessful();
 $client->get('http://example.com/contact')->assertRedirect('https://example.com/contact');
 
-$client->histroy()->last()->request()->assertUriQueryNotHasKey('age');
+$client->lastRequest()->assertUriQueryNotHasKey('age');
 ```
 
 ## Change log

--- a/src/ArrayAccessible.php
+++ b/src/ArrayAccessible.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Muzzle;
+
+use ArrayIterator;
+
+trait ArrayAccessible
+{
+
+    protected $items = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator() : ArrayIterator
+    {
+
+        return new ArrayIterator($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset) : bool
+    {
+
+        return isset($this->items[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+
+        return $this->items[$offset] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value) : self
+    {
+
+        if ($offset === null) {
+            $this->items[] = $value;
+        } else {
+            $this->items[$offset] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset) : void
+    {
+
+        unset($this->items[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count() : int
+    {
+
+        return count($this->items);
+    }
+}

--- a/src/Messages/Transaction.php
+++ b/src/Messages/Transaction.php
@@ -16,7 +16,7 @@ class Transaction implements ArrayAccess
     protected $request;
     protected $response;
     protected $error;
-    protected $options;
+    protected $options = [];
 
     public static function new()
     {

--- a/src/Muzzle.php
+++ b/src/Muzzle.php
@@ -7,6 +7,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use Muzzle\Assertions\AssertionRules;
+use Muzzle\Messages\AssertableRequest;
 use Muzzle\Messages\Transaction;
 use Muzzle\Middleware\Assertable;
 use Muzzle\Middleware\History;
@@ -128,6 +129,18 @@ class Muzzle implements ClientInterface
     {
 
         return $this->history;
+    }
+
+    public function lastRequest() : AssertableRequest
+    {
+
+        return $this->history->last()->request();
+    }
+
+    public function firstRequest() : AssertableRequest
+    {
+
+        return $this->history->first()->request();
     }
 
     public function expectations() : Transactions

--- a/src/NotATransaction.php
+++ b/src/NotATransaction.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Muzzle;
+
+use Throwable;
+use UnexpectedValueException;
+
+class NotATransaction extends UnexpectedValueException
+{
+
+    public static function value($value) : Throwable
+    {
+
+        return new static(sprintf(
+            'Expected an array of transactions but got an array value of type: %s',
+            is_object($value) ? get_class($value) : gettype($value)
+        ));
+    }
+}

--- a/src/WrapsGuzzle.php
+++ b/src/WrapsGuzzle.php
@@ -93,7 +93,7 @@ trait WrapsGuzzle
                 $method,
                 $dumper->dump((new VarCloner)->cloneVar($arguments), true)
             ));
-            throw $exception;
+            throw $exception; // @codeCoverageIgnore
         }
     }
 }

--- a/tests/MuzzleTest.php
+++ b/tests/MuzzleTest.php
@@ -6,9 +6,9 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Muzzle\Messages\AssertableRequest;
 use Muzzle\Messages\Transaction;
 use Muzzle\Middleware\Decodable;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 class MuzzleTest extends TestCase
@@ -94,5 +94,31 @@ class MuzzleTest extends TestCase
         $client->flush();
 
         $this->assertEmpty(Muzzle::container());
+    }
+
+    /** @test */
+    public function itCanGetTheLastRequest()
+    {
+
+        $muzzle = new Muzzle;
+        $request = AssertableRequest::fromBaseRequest(new Request(HttpMethod::GET, '/'));
+        $transaction = (new Transaction)->setRequest($request);
+        $muzzle->setHistory(new Transactions([new Transaction, $transaction]));
+
+        $this->assertSame($request, $muzzle->lastRequest());
+        Muzzle::flush();
+    }
+
+    /** @test */
+    public function itCanGetTheFirstRequest()
+    {
+
+        $muzzle = new Muzzle;
+        $request = AssertableRequest::fromBaseRequest(new Request(HttpMethod::GET, '/'));
+        $transaction = (new Transaction)->setRequest($request);
+        $muzzle->setHistory(new Transactions([$transaction, new Transaction]));
+
+        $this->assertSame($request, $muzzle->firstRequest());
+        Muzzle::flush();
     }
 }

--- a/tests/NotATransactionTest.php
+++ b/tests/NotATransactionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Muzzle;
+
+use PHPUnit\Framework\TestCase;
+
+class NotATransactionTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider variableTypes
+     * @param mixed $value
+     * @param string $type
+     */
+    public function itWillReturnAThrowableInstanceWithAMessageDescribingTheProvidedType($value, $type)
+    {
+
+        $this->assertRegExp("/.*{$type}$/", NotATransaction::value($value)->getMessage());
+    }
+
+    public function variableTypes() : \Generator
+    {
+
+        yield from [
+            [['foo'], 'array'],
+            [new \DateTime, \DateTime::class],
+            [true, 'boolean'],
+            ['foo', 'string'],
+            [5, 'integer'],
+            [3.14, 'double'],
+        ];
+    }
+}

--- a/tests/TransactionsTest.php
+++ b/tests/TransactionsTest.php
@@ -21,7 +21,19 @@ class TransactionsTest extends TestCase
         $last = new Transaction;
         $transactions->push($last);
 
-        $this->assertSame($last, last($transactions->transactions()));
+        $this->assertSame($last, $transactions->last());
+    }
+
+    /** @test */
+    public function itCanPrependAnItemOntoTheTopOfTheTransactionStack()
+    {
+
+        $transactions = new Transactions([new Transaction, new Transaction]);
+
+        $first = new Transaction;
+        $transactions->prepend($first);
+
+        $this->assertSame($first, $transactions->first());
     }
 
     /** @test */
@@ -79,5 +91,93 @@ class TransactionsTest extends TestCase
         unset($transactions['foo']);
         $this->assertFalse(isset($transactions['foo']));
         $this->assertSame($first, $transactions[0]);
+    }
+
+    /** @test */
+    public function itCanRetrieveATransactionByKey()
+    {
+
+        $first = (new Transaction)->setOptions(['first']);
+        $last = (new Transaction)->setOptions(['last']);
+        $transactions = new Transactions([$first, new Transaction, $last]);
+
+
+        $this->assertSame($first, $transactions->get(0));
+        $this->assertSame($last, $transactions->get($transactions->count() - 1));
+    }
+
+    /** @test */
+    public function itCanMapOverTheTransactions()
+    {
+
+        $transactions = new Transactions([new Transaction, new Transaction]);
+        $transactions = $transactions->map(function (Transaction $transaction) {
+
+            return $transaction->setOptions(['mapped']);
+        });
+
+        foreach ($transactions as $transaction) {
+            $this->assertEquals(['mapped'], $transaction->options());
+        }
+    }
+
+    /** @test */
+    public function itCanFilterOutTransactions()
+    {
+
+        $exclude = (new Transaction)->setOptions(['exclude']);
+        $transactions = new Transactions([new Transaction, $exclude, new Transaction]);
+
+        $filtered = $transactions->filter(function (Transaction $transaction) {
+            return array_search('exclude', $transaction->options()) === false;
+        });
+
+        foreach ($filtered as $transaction) {
+            $this->assertNotSame($exclude, $transaction);
+        }
+    }
+
+    /** @test */
+    public function itCanGetATransactionByKeyOrReturnNullIfItsNotFound()
+    {
+
+        $second = new Transaction;
+        $transactions = new Transactions([new Transaction, $second, new Transaction]);
+
+        $this->assertSame($second, $transactions->get(1));
+        $this->assertNull($transactions->get(999));
+    }
+
+    /** @test */
+    public function itCanCheckIfTheTransactionsCollectionContainsAListOfTransactionsByKeys()
+    {
+
+        $transactions = new Transactions([new Transaction, new Transaction, new Transaction]);
+
+        $this->assertTrue($transactions->has(0, 1));
+        $this->assertFalse($transactions->has(999));
+    }
+
+    /** @test */
+    public function itCanReportIfTheTransactionsCollectionIsEmptyOrNot()
+    {
+
+        $transactions = new Transactions;
+        $this->assertTrue($transactions->isEmpty());
+        $this->assertFalse($transactions->isNotEmpty());
+
+        $transactions->push(new Transaction);
+        $this->assertFalse($transactions->isEmpty());
+        $this->assertTrue($transactions->isNotEmpty());
+    }
+
+    /** @test */
+    public function itCanReturnAnArrayOfTheContainedTransactions()
+    {
+
+        $transactions = [new Transaction, new Transaction, new Transaction];
+        $instance = new Transactions($transactions);
+
+        $this->assertSame($transactions, $instance->transactions());
     }
 }


### PR DESCRIPTION
## Description

This PR adds a number of Collection methods (largely based on Laravel's `Collection` class) to make the `Transactions` collection more useful. I debated extending or decorating Laravel's `Collection`, but most of those methods don't make sense for this use case and IntelliSense doesn't know to expect all contained items to be a `Transaction` instance.

It also adds `firstRequest` and `lastRequest` helper methods to the `Muzzle` instance.

## Motivation and context

The current way to use `Transactions`:
```php
$transactions = [new Transaction, new Transaction, new Transaction];
$instance = new Transactions($transactions);
$instance->transactions()[2]->request(); // no intellisense
// or from a `Muzzle` instance
$muzzle->history()->last()->request();
```
The new way:
```php
$transactions = [new Transaction, new Transaction, new Transaction];
$instance = new Transactions($transactions);
$instance->get(2)->request(); // intellisense works
// or from a `Muzzle` instance
$muzzle->lastRequest();
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
