### PR TITLE
Expect Request JSON Contains Instead of Exact Match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## [0.1.2] - 2018-06-22
+## [0.2.0] - 2018-06-27
 
 ### Added
 - route pattern matching on path assertions
 - improved `Transactions` usability
 - added shortcut methods to first and last request on the `Muzzle` instance
+- replaced exact match with a contains check for the request body default assertion
+- added `setJson` helper to automatically `json_encode`the provided body when building requests
 
 ### Deprecated
 - Nothing

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ By default `Muzzle` will run assertions that:
 - assert the expected request URI matches the actual request URI (including a configured `base_uri`)
 - assert the expected request method matches the actual request method
 - assert the expected request query (if provided) is contained in the actual request query
-- assert the expected request body (if provided) matches the actual request body
+- assert the expected request body (if provided) is contained in the actual request body
 - assert the expected request headers (if provided) are contained in the actual request headers
 
 Custom assertion rules can be added by implementing the `Assertion` interface and using `AssertionRules::push` or 

--- a/src/Assertions/AssertionRules.php
+++ b/src/Assertions/AssertionRules.php
@@ -14,7 +14,7 @@ class AssertionRules
         UriPathMatches::class,
         MethodMatches::class,
         QueryContains::class,
-        BodyMatches::class,
+        RequestContainsJson::class,
         HeadersMatch::class,
     ];
 

--- a/src/Assertions/RequestContainsJson.php
+++ b/src/Assertions/RequestContainsJson.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Muzzle\Assertions;
+
+use Muzzle\Messages\Transaction;
+
+class RequestContainsJson implements Assertion
+{
+
+    public function assert(Transaction $actual, Transaction $expected) : void
+    {
+
+        $actual->request()->assertJson(
+            (array) json_decode($expected->request()->getBody(), true)
+        );
+    }
+}

--- a/src/MuzzleBuilder.php
+++ b/src/MuzzleBuilder.php
@@ -172,6 +172,14 @@ class MuzzleBuilder
         return $this;
     }
 
+    public function setJson(array $body) : MuzzleBuilder
+    {
+
+        $this->builder()->setJson($body);
+
+        return $this;
+    }
+
     public function setQuery(array $query = []) : MuzzleBuilder
     {
 

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -93,6 +93,14 @@ class RequestBuilder
         return $this;
     }
 
+    public function setJson(array $body) : RequestBuilder
+    {
+
+        $this->body = json_encode($body);
+
+        return $this;
+    }
+
     public function setQuery(array $query = []) : RequestBuilder
     {
 

--- a/tests/Assertions/RequestContainsJsonTest.php
+++ b/tests/Assertions/RequestContainsJsonTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Muzzle\Assertions;
+
+use Muzzle\HttpMethod;
+use Muzzle\Messages\AssertableRequest;
+use Muzzle\Messages\Transaction;
+use Muzzle\RequestBuilder;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+class RequestContainsJsonTest extends TestCase
+{
+
+    /** @test */
+    public function itFailsIfTheActualRequestDoesNotContainTheExpectedJson()
+    {
+
+        $expected = (new Transaction)->setRequest(
+            (new RequestBuilder)->setJson(['foo' => 'bar'])->build()
+        );
+        $actual = (new Transaction)->setRequest(new AssertableRequest(
+            (new RequestBuilder(HttpMethod::GET()))
+                ->setBody('test body')
+                ->build()
+        ));
+
+        $this->expectException(ExpectationFailedException::class);
+        (new RequestContainsJson)->assert($actual, $expected);
+    }
+
+    /** @test */
+    public function itDoesNotFailIfTheActualRequestContainsTheExpectedJson()
+    {
+
+        $expected = (new Transaction)->setRequest(
+            (new RequestBuilder)->setJson(['foo' => 'bar'])->build()
+        );
+        $actual = (new Transaction)->setRequest(new AssertableRequest(
+            (new RequestBuilder(HttpMethod::GET()))
+                ->setJson([
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ])
+                ->build()
+        ));
+
+        (new RequestContainsJson)->assert($actual, $expected);
+    }
+}

--- a/tests/MuzzleBuilderTest.php
+++ b/tests/MuzzleBuilderTest.php
@@ -127,6 +127,30 @@ class MuzzleBuilderTest extends TestCase
     }
 
     /** @test */
+    public function itCanBuildARequestExpectationWithJson()
+    {
+
+        $client = MuzzleBuilder::create()
+                               ->setMethod(HttpMethod::GET())
+                               ->setUri('/')
+                               ->setJson(['json' => 'testing body'])
+                               ->withMiddleware(new Assertable)
+                               ->build();
+
+        $client->get('/', [
+            'json' => ['json' => 'testing body'],
+        ]);
+
+        $request = $client->expectations()->first()->request();
+
+
+        (new AssertableRequest($request))
+            ->assertMethod(HttpMethod::GET)
+            ->assertUriPath('/')
+            ->assertJson(['json' => 'testing body']);
+    }
+
+    /** @test */
     public function itUsesHttpMethodsToCreateRequestBuildersForTheGivenMethod()
     {
 


### PR DESCRIPTION
## Description

This PR replaces the exact body match default assertion with a contains check. This will allow for a quick way to test that a value you care about is in the assertion, while avoiding having to reproduce the entire payload body.
It also adds `setJson` helper to automatically `json_encode`the provided body when building requests.

## Motivation and context

This change makes testing for a particular value in the payload much less of a hassle:
```php
Muzzle::builder()
  ->post('/foo')
  ->setJson(['data' => ['relevant_key' => 'expected_value']])
  ->replyWith(fixture('my_fixture.json'))
  ->replace();
```
The above example will match a payload such as:
```json
{
    "data": {
        "id": "517",
        "relevant_key": "expected_value",
        "another_key": "another_value",
        "some_other_key": "some_other_value",
    }
}
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
