### PR TITLE
Miscellaneous Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - added shortcut methods to first and last request on the `Muzzle` instance
 - replaced exact match with a contains check for the request body default assertion
 - added `setJson` helper to automatically `json_encode`the provided body when building requests
+- allow `JsonFixture` to be cast to a string
+- added `setJson` helper to `ResponseBuilder`
+- name middleware when added and insure they come before history
 
 ### Deprecated
 - Nothing

--- a/src/Messages/JsonFixture.php
+++ b/src/Messages/JsonFixture.php
@@ -137,4 +137,10 @@ class JsonFixture implements ResponseInterface, ArrayAccess
 
         $this->forget($offset);
     }
+
+    public function __toString() : string
+    {
+
+        return (string) $this->getBody();
+    }
 }

--- a/src/Muzzle.php
+++ b/src/Muzzle.php
@@ -103,7 +103,7 @@ class Muzzle implements ClientInterface
     {
 
         foreach ($middlewares as $middleware) {
-            $this->stack->push($middleware);
+            $this->stack->before('history', $middleware, is_object($middleware) ? get_class($middleware) : '');
         }
 
         return $this;

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -90,6 +90,17 @@ class ResponseBuilder
         return $this;
     }
 
+    /**
+     * @param mixed $body
+     * @return ResponseBuilder
+     */
+    public function setJson($body) : ResponseBuilder
+    {
+
+        $this->body = \GuzzleHttp\json_encode($body);
+        return $this;
+    }
+
     public function setBodyFromFixture(string $path) : ResponseBuilder
     {
 

--- a/tests/Messages/JsonFixtureTest.php
+++ b/tests/Messages/JsonFixtureTest.php
@@ -108,4 +108,12 @@ class JsonFixtureTest extends TestCase
         $this->assertTrue($fixture->has('data.foo'));
         $this->assertFalse(isset($fixture['data.missing']));
     }
+
+    /** @test */
+    public function itCanBeCastToAString()
+    {
+
+        $body = json_encode(['data' => ['foo' => 'bar']]);
+        $this->assertSame($body, (string) new JsonFixture(HttpMethod::GET, [], $body));
+    }
 }

--- a/tests/ResponseBuilderTest.php
+++ b/tests/ResponseBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Muzzle;
 
+use GuzzleHttp\Psr7\Response;
 use Muzzle\Messages\JsonFixture;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -59,5 +60,15 @@ class ResponseBuilderTest extends TestCase
         $fixture = ResponseBuilder::fromFixture('response.json');
 
         $this->assertInstanceOf(JsonFixture::class, $fixture);
+    }
+
+    /** @test */
+    public function itCanSetTheBodyAsJsonFromAnArray()
+    {
+
+        $data = ['data' => ['message' => 'done']];
+        $response = (new ResponseBuilder)->setJson($data)->build();
+
+        $this->assertEquals(json_encode($data), $response->getBody()->getContents());
     }
 }


### PR DESCRIPTION
## Description

A handful of small updates:
- allow `JsonFixture` to be cast to a string
- added `setJson` helper to `ResponseBuilder`
- name middleware when added and insure they come before history