### PR TITLE
updated fixture to use fromBaseResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [0.3.1] - 2018-12-06
+
+### Added
+- Nothing
+
+### Fixed
+- overrode `fromBaseResponse` on fixture class to call `fromResponse` to fix issue on `with` calls
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## [0.3.0] - 2018-10-04
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "~7.1",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3",
         "hamcrest/hamcrest-php": "^2.0",
         "illuminate/support": "^5.5",

--- a/src/Messages/JsonFixture.php
+++ b/src/Messages/JsonFixture.php
@@ -46,6 +46,12 @@ class JsonFixture implements ResponseInterface, ArrayAccess
         return new static($response->getStatusCode(), $response->getHeaders(), $response->getBody());
     }
 
+    public static function fromBaseResponse(ResponseInterface $response) : JsonFixture
+    {
+
+        return static::fromResponse($response);
+    }
+
     public function getBody()
     {
 


### PR DESCRIPTION
## Description

Overrode `fromBaseResponse` on `JsonFixture` to call `fromResponse`.

## Motivation and context

Fixes a bug when calling the `with` methods on the `JsonFixture`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.