### PR TITLE
Improve `Assert::assertArraysMatch` Failure Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `Muzzle` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [0.3.2] - 2019-01-03
+
+### Added
+- Nothing
+
+### Fixed
+- updated `Assert::assertArraysMatch` failure messages to give more details
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
 ## [0.3.1] - 2018-12-06
 
 ### Added

--- a/src/Assertions/Assert.php
+++ b/src/Assertions/Assert.php
@@ -4,6 +4,7 @@ namespace Muzzle\Assertions;
 
 use Muzzle\CliFormatter;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\IsType;
 use function Muzzle\is_regex;
 
 class Assert
@@ -16,10 +17,17 @@ class Assert
             PHPUnit::assertArrayHasKey(
                 $key,
                 $actual,
-                "The array does not contain contain the expected key [{$key}]."
+                "Did not find the expected key [{$key}] in the provided content:" . PHP_EOL
+                . CliFormatter::format($actual)
             );
 
             if (is_regex($value)) {
+                PHPUnit::assertInternalType(
+                    IsType::TYPE_SCALAR,
+                    $actual[$key],
+                    "Cannot match pattern [{$value}] against non-string value:" . PHP_EOL
+                    . CliFormatter::format($actual[$key])
+                );
                 PHPUnit::assertRegExp($value, $actual[$key]);
                 continue;
             }


### PR DESCRIPTION
## Description

Updated `Assert::assertArraysMatch` failure messages to give more details

## Motivation and context

When a key isn't found, instead of returning a fairly useless message of:
`The array does not contain contain the expected key ['foo'].`
We'll instead also provide the content that the key was searched against:
```
Did not find the expected key [foo] in the provided content:
[
  "bar" => [
    'baz',
  ]
]
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)