### PR TITLE
record body mutations to fixtures wrapped response

### DIFF
--- a/src/Messages/JsonFixture.php
+++ b/src/Messages/JsonFixture.php
@@ -62,6 +62,8 @@ class JsonFixture implements ResponseInterface, ArrayAccess
     {
 
         $this->body = json_decode($body, true);
+        $this->saveBody();
+
         return $this;
     }
 
@@ -91,7 +93,7 @@ class JsonFixture implements ResponseInterface, ArrayAccess
     public function set(string $key, $value) : JsonFixture
     {
 
-        Arr::set($this->body, $key, $value);
+        $this->saveBody(Arr::set($this->body, $key, $value));
 
         return $this;
     }
@@ -100,6 +102,7 @@ class JsonFixture implements ResponseInterface, ArrayAccess
     {
 
         Arr::forget($this->body, $key);
+        $this->saveBody();
     }
 
     public function only(array $keys) : array
@@ -157,5 +160,11 @@ class JsonFixture implements ResponseInterface, ArrayAccess
     {
 
         return (string) $this->getBody();
+    }
+
+    private function saveBody() : void
+    {
+
+        $this->initialize($this->response->withBody($this->getBody()));
     }
 }

--- a/tests/Messages/JsonFixtureTest.php
+++ b/tests/Messages/JsonFixtureTest.php
@@ -133,4 +133,17 @@ class JsonFixtureTest extends TestCase
         $this->assertEquals(HttpStatus::NOT_MODIFIED, $response->getStatusCode());
         $this->assertNotSame($fixture, $response);
     }
+
+    /** @test */
+    public function itWillRetainChangesWhenCallingWithMethods() : void
+    {
+
+        $fixture = new JsonFixture(HttpStatus::OK, ['foo' => 'bar'], json_encode(['data' => ['foo' => 'bar']]));
+        $fixture->set('data.foo', 'baz');
+        $response = $fixture->withoutHeader('foo');
+
+        $this->assertFalse($response->hasHeader('foo'));
+        $this->assertEquals('baz', $response->get('data.foo'), 'The modified value was not retained.');
+        $this->assertNotSame($fixture, $response);
+    }
 }


### PR DESCRIPTION
Fixes an issue where the base response's `with` methods would return the initial body rather than the modified one.

On each write method, the fixture's wrapped response is updated with the new body.