### PR TITLE
Helper for matching a list in any order

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -61,3 +61,18 @@ function is_json($value) : bool
     json_decode($value);
     return json_last_error() === JSON_ERROR_NONE;
 }
+
+/**
+ * Returns a regex pattern to see if a list of items appear in any order.
+ *
+ * @param string ...$options
+ * @return string
+ */
+function in_any_order(string ...$options) : string
+{
+
+    return sprintf('/%s/', implode('', array_map(function ($field) {
+
+        return "(?=.*{$field})";
+    }, $options)));
+}

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -79,4 +79,19 @@ class FunctionsTest extends TestCase
         $this->assertTrue(is_json($valid));
         $this->assertFalse(is_json($invalid));
     }
+
+    /** @test */
+    public function itReturnsARegexPatternToSeeIfAListOfItemsAppearInAnyOrder() : void
+    {
+
+        $items = ['foo', 'bar', 'baz'];
+        $shuffle = $items;
+        shuffle($shuffle);
+        $subject = implode(',', $shuffle);
+
+        $pattern = in_any_order(...$items);
+
+        $this->assertEquals('/(?=.*foo)(?=.*bar)(?=.*baz)/', $pattern);
+        $this->assertRegExp($pattern, $subject);
+    }
 }


### PR DESCRIPTION
A quick helper function for doing a regex match against a list of items in any order. The primary use case is when searching a query string or comma separated list.
e.g.
```php
Muzzle::builder()
  ->get('/')
  ->query(['tags' => in_any_order('sport', 'game', 'activity')])
  ->build();
```