### PR TITLE
Edits to make Muzzle compatible with PHPUnit 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 build
 composer.lock
 vendor
-.idea
-.phpunit.result.cache
-tests/.phpunit.result.cache
-tests/Assertions/.phpunit.result.cache
-tests/Messages/.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 build
 composer.lock
 vendor
+.idea
+.phpunit.result.cache
+tests/.phpunit.result.cache
+tests/Assertions/.phpunit.result.cache
+tests/Messages/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,16 @@
         }
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.2",
         "ext-json": "*",
         "ext-dom": "*",
         "guzzlehttp/guzzle": "^6.3",
         "hamcrest/hamcrest-php": "^2.0",
         "illuminate/support": "^5.5",
         "myclabs/php-enum": "^1.5",
-        "phpunit/phpunit": "^7.1",
-        "symfony/var-dumper": "^4.0"
+        "phpunit/phpunit": "^8.0",
+        "symfony/var-dumper": "^4.0",
+        "dms/phpunit-arraysubset-asserts": "^0.1.0"
     },
     "require-dev": {
         "php-vfs/php-vfs": "^1.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Assertions/Assert.php
+++ b/src/Assertions/Assert.php
@@ -4,7 +4,6 @@ namespace Muzzle\Assertions;
 
 use Muzzle\CliFormatter;
 use PHPUnit\Framework\Assert as PHPUnit;
-use PHPUnit\Framework\Constraint\IsType;
 use function Muzzle\is_regex;
 
 class Assert
@@ -22,8 +21,7 @@ class Assert
             );
 
             if (is_regex($value)) {
-                PHPUnit::assertInternalType(
-                    IsType::TYPE_SCALAR,
+                PHPUnit::assertIsScalar(
                     $actual[$key],
                     "Cannot match pattern [{$value}] against non-string value:" . PHP_EOL
                     . CliFormatter::format($actual[$key])

--- a/src/Messages/AssertableRequest.php
+++ b/src/Messages/AssertableRequest.php
@@ -2,7 +2,6 @@
 
 namespace Muzzle\Messages;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use GuzzleHttp\Psr7;
 use Illuminate\Support\Str;
@@ -16,7 +15,6 @@ class AssertableRequest implements RequestInterface
     use ContentAssertions;
     use RequestDecorator;
     use JsonMessage;
-    use ArraySubsetAsserts;
 
     /**
      * Asserts that the request contains the given header and equals the optional value.
@@ -48,7 +46,7 @@ class AssertableRequest implements RequestInterface
                 implode(', ', $expected)
             );
 
-            static::assertArraySubset($expected, $actual, $message);
+            self::assertArraySubset($expected, $actual, $message);
         }
 
         return $this;
@@ -275,7 +273,7 @@ class AssertableRequest implements RequestInterface
     {
 
         $query = Psr7\parse_query($this->getUri()->getQuery());
-        static::assertArraySubset($values, $query, false, (function ($expected, $actual) {
+        self::assertArraySubset($values, $query, false, (function ($expected, $actual) {
 
             return 'Could not find ' . PHP_EOL
                    . CliFormatter::format($expected) . PHP_EOL

--- a/src/Messages/AssertableRequest.php
+++ b/src/Messages/AssertableRequest.php
@@ -2,6 +2,8 @@
 
 namespace Muzzle\Messages;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Exception;
 use GuzzleHttp\Psr7;
 use Illuminate\Support\Str;
 use Muzzle\CliFormatter;
@@ -14,6 +16,7 @@ class AssertableRequest implements RequestInterface
     use ContentAssertions;
     use RequestDecorator;
     use JsonMessage;
+    use ArraySubsetAsserts;
 
     /**
      * Asserts that the request contains the given header and equals the optional value.
@@ -21,6 +24,7 @@ class AssertableRequest implements RequestInterface
      * @param  string $headerName
      * @param  mixed $value
      * @return $this
+     * @throws Exception
      */
     public function assertHeader($headerName, $value = null)
     {
@@ -44,7 +48,7 @@ class AssertableRequest implements RequestInterface
                 implode(', ', $expected)
             );
 
-            PHPUnit::assertArraySubset($expected, $actual, $message);
+            static::assertArraySubset($expected, $actual, $message);
         }
 
         return $this;
@@ -265,12 +269,13 @@ class AssertableRequest implements RequestInterface
      *
      * @param  array $values
      * @return $this
+     * @throws Exception
      */
     public function assertUriQueryContains(array $values)
     {
 
         $query = Psr7\parse_query($this->getUri()->getQuery());
-        PHPUnit::assertArraySubset($values, $query, false, (function ($expected, $actual) {
+        static::assertArraySubset($values, $query, false, (function ($expected, $actual) {
 
             return 'Could not find ' . PHP_EOL
                    . CliFormatter::format($expected) . PHP_EOL

--- a/src/Messages/AssertableResponse.php
+++ b/src/Messages/AssertableResponse.php
@@ -60,7 +60,10 @@ class AssertableResponse extends DecodableResponse
         );
 
         if (! is_null($uri)) {
-            PHPUnit::assertContains(app('url')->to($uri), $this->getHeader('Location'), '', true);
+            $locationTo = app('url')->to($uri);
+            foreach ($this->getHeader('Location') as $location) {
+                PHPUnit::assertEqualsIgnoringCase($locationTo, $location);
+            }
         }
 
         return $this;

--- a/src/Messages/ContentAssertions.php
+++ b/src/Messages/ContentAssertions.php
@@ -2,18 +2,22 @@
 
 namespace Muzzle\Messages;
 
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Muzzle\CliFormatter;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Psr\Http\Message\StreamInterface;
 
 trait ContentAssertions
 {
+    use ArraySubsetAsserts;
 
     /**
      * Gets the body of the message.
      *
-     * @return \Psr\Http\Message\StreamInterface Returns the body as a stream.
+     * @return StreamInterface Returns the body as a stream.
      */
     abstract public function getBody();
 
@@ -33,7 +37,7 @@ trait ContentAssertions
     public function assertSee($value) : self
     {
 
-        PHPUnit::assertContains($value, (string) $this->getBody());
+        PHPUnit::assertStringContainsString($value, (string) $this->getBody());
 
         return $this;
     }
@@ -47,7 +51,7 @@ trait ContentAssertions
     public function assertSeeText($value) : self
     {
 
-        PHPUnit::assertContains($value, strip_tags((string) $this->getBody()));
+        PHPUnit::assertStringContainsString($value, strip_tags((string) $this->getBody()));
 
         return $this;
     }
@@ -61,7 +65,7 @@ trait ContentAssertions
     public function assertDoNotSee($value) : self
     {
 
-        PHPUnit::assertNotContains($value, (string) $this->getBody());
+        PHPUnit::assertStringNotContainsString($value, (string) $this->getBody());
 
         return $this;
     }
@@ -75,7 +79,7 @@ trait ContentAssertions
     public function assertDoNotSeeText($value) : self
     {
 
-        PHPUnit::assertNotContains($value, strip_tags((string) $this->getBody()));
+        PHPUnit::assertStringNotContainsString($value, strip_tags((string) $this->getBody()));
 
         return $this;
     }
@@ -85,11 +89,12 @@ trait ContentAssertions
      *
      * @param  array $data
      * @return $this
+     * @throws Exception
      */
     public function assertJson(array $data) : self
     {
 
-        PHPUnit::assertArraySubset(
+        self::assertArraySubset(
             $data,
             $this->decode(),
             false,
@@ -192,6 +197,7 @@ trait ContentAssertions
      * @param  array|null $structure
      * @param  array|null $responseData
      * @return $this
+     * @throws Exception
      */
     public function assertJsonStructure(array $structure = null, array $responseData = null) : self
     {
@@ -206,7 +212,7 @@ trait ContentAssertions
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                PHPUnit::assertInternalType('array', $responseData);
+                PHPUnit::assertIsArray($responseData);
 
                 foreach ($responseData as $responseDataItem) {
                     $this->assertJsonStructure($structure['*'], $responseDataItem);
@@ -232,7 +238,7 @@ trait ContentAssertions
     }
 
     /**
-     * @param string|\Psr\Http\Message\StreamInterface $body
+     * @param string|StreamInterface $body
      * @return $this
      */
     public function assertBodyEquals($body) : self

--- a/tests/Assertions/BodyMatchesTest.php
+++ b/tests/Assertions/BodyMatchesTest.php
@@ -25,7 +25,7 @@ class BodyMatchesTest extends TestCase
         );
 
         $this->expectException(ExpectationFailedException::class);
-        $expectation($actual, new Muzzle);
+        $expectation($actual);
     }
 
     /** @test */
@@ -39,12 +39,9 @@ class BodyMatchesTest extends TestCase
                 ->build()
         );
 
-        $expectation($assertable, new Muzzle);
+        $expectation($assertable);
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('test not matching')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('test not matching')));
     }
 
     /** @test */
@@ -60,12 +57,9 @@ class BodyMatchesTest extends TestCase
                 ->build()
         );
 
-        $expectation($assertable, new Muzzle);
+        $expectation($assertable);
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('test not matching')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('test not matching')));
     }
 
     /** @test */
@@ -80,13 +74,10 @@ class BodyMatchesTest extends TestCase
                 ->setBody('test body')
                 ->build()
         );
-        $expectation($assertable, new Muzzle);
-        $expectation($assertable->withBody(stream_for('test box')), new Muzzle);
+        $expectation($assertable);
+        $expectation($assertable->withBody(stream_for('test box')));
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('test not matching')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('test not matching')));
     }
 
     /** @test */
@@ -101,12 +92,9 @@ class BodyMatchesTest extends TestCase
                 ->setBody($body)
                 ->build()
         );
-        $expectation($assertable, new Muzzle);
+        $expectation($assertable);
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')));
     }
 
     /** @test */
@@ -121,12 +109,9 @@ class BodyMatchesTest extends TestCase
                 ->setBody('{"data" : [{"foo": {"bar": "baz"}}]}')
                 ->build()
         );
-        $expectation($assertable, new Muzzle);
+        $expectation($assertable);
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')));
     }
 
     /** @test */
@@ -141,15 +126,9 @@ class BodyMatchesTest extends TestCase
                 ->setBody('{"data" : [{"foo": {"bar": "baz"}}]}')
                 ->build()
         );
-        $expectation($assertable, new Muzzle);
-        $expectation(
-            $assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "buzz"}}]}')),
-            new Muzzle
-        );
+        $expectation($assertable);
+        $expectation($assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "buzz"}}]}')));
         $this->expectException(ExpectationFailedException::class);
-        $expectation(
-            $assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')),
-            new Muzzle
-        );
+        $expectation($assertable->withBody(stream_for('{"data" : [{"foo": {"bar": "qux"}}]}')));
     }
 }

--- a/tests/MuzzleBuilderTest.php
+++ b/tests/MuzzleBuilderTest.php
@@ -178,6 +178,6 @@ class MuzzleBuilderTest extends TestCase
 
         $stack = $muzzle->getConfig('handler');
 
-        $this->assertContains(Decodable::class, (string) $stack);
+        $this->assertStringContainsString(Decodable::class, (string) $stack);
     }
 }


### PR DESCRIPTION
- Updates to code to be compatible with PHPUnit 8
- Updated dependencies for compatibility
- Minor edits to remove warnings in code.
- Bumps minimum required php version to 7.2

**Note**: due to the bump in minimum required php version this should probably be released as a major release.